### PR TITLE
FEAT: introduce Tarmoqchi binary wrapper and set as default package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
           tarmoqchi = pkgs.runCommand "tarmoqchi-wrappper" {} ''
             mkdir -p $out/bin
             ln -s ${cli}/bin/cli $out/bin/tarmoqchi
-          ''
+          '';
 
           default = tarmoqchi;
         };

--- a/flake.nix
+++ b/flake.nix
@@ -34,10 +34,16 @@
         };
 
         # Output package
-        packages = {
-          default = self.packages.${system}.cli;
+        packages = rec {
           cli = pkgs.callPackage ./cli/default.nix {inherit pkgs;};
           server = pkgs.callPackage ./server/default.nix {inherit pkgs;};
+
+          tarmoqchi = pkgs.runCommand "tarmoqchi-wrappper" {} ''
+            mkdir -p $out/bin
+            ln -s ${cli}/bin/cli $out/bin/tarmoqchi
+          ''
+
+          default = tarmoqchi;
         };
       }
     )


### PR DESCRIPTION
This PR formalizes the project's identity by introducing the tarmoqchi wrapper. Instead of calling a generic `cli` binary, users can now interact with the project using its namesake command.

### What's changed

- **New Wrapper**: Added a runCommand called tarmoqchi-wrapper that symlinks the cli binary to a new tarmoqchi command
- **Default Update**: Updated the default flake package to point to tarmoqchi instead of the raw cli package.