### PR TITLE
fix: add backward compability

### DIFF
--- a/cli/main.go
+++ b/cli/main.go
@@ -37,6 +37,7 @@ const (
 const (
 	NotRunningAppOfClient ResponseType = "NOT_RUNNING_APP_OF_CLIENT"
 	ResponseChunk         ResponseType = "RESPONSE_CHUNK"
+	ResponseChunkBase64   ResponseType = "RESPONSE_CHUNK_BASE64"
 )
 
 type ForwardInfo struct {
@@ -451,7 +452,7 @@ func requestSender(request *Request, wsManager *WebSocketManager, localPort stri
 				StatusCode:   resp.StatusCode,
 				Body:         chunk,
 				Last:         last,
-				ResponseType: ResponseChunk,
+				ResponseType: ResponseChunkBase64,
 				Headers:      flattenHeaders(resp.Header),
 			}
 
@@ -469,7 +470,7 @@ func requestSender(request *Request, wsManager *WebSocketManager, localPort stri
 			StatusCode:   resp.StatusCode,
 			Body:         responseBody,
 			Last:         true,
-			ResponseType: ResponseChunk,
+			ResponseType: ResponseChunkBase64,
 			Headers:      flattenHeaders(resp.Header),
 		}
 

--- a/server/src/main/java/uz/server/controller/ForwardController.java
+++ b/server/src/main/java/uz/server/controller/ForwardController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import uz.server.domain.enums.RequestType;
+import uz.server.domain.enums.ResponseType;
 import uz.server.domain.exception.BaseException;
 import uz.server.domain.model.ForwardInfo;
 import uz.server.domain.model.Request;
@@ -94,7 +95,13 @@ public class ForwardController {
       httpHeaders.set("Access-Control-Allow-Headers", "*");
       httpHeaders.set("Access-Control-Allow-Credentials", "true");
 
-        byte[] responseBody = Base64.getDecoder().decode(response.getBody());
+        byte[] responseBody;
+
+        if (response.getResponseType() == ResponseType.RESPONSE_CHUNK_BASE64) {
+            responseBody = Base64.getDecoder().decode(response.getBody());
+        } else {
+            responseBody = response.getBody() != null ? response.getBody().getBytes() : new byte[0];
+        }
 
         return ResponseEntity.status(response.getStatus()).headers(httpHeaders).body(responseBody);
     }

--- a/server/src/main/java/uz/server/domain/enums/ResponseType.java
+++ b/server/src/main/java/uz/server/domain/enums/ResponseType.java
@@ -2,5 +2,6 @@ package uz.server.domain.enums;
 
 public enum ResponseType {
     NOT_RUNNING_APP_OF_CLIENT,
-    RESPONSE_CHUNK
+    RESPONSE_CHUNK,
+    RESPONSE_CHUNK_BASE64,
 }


### PR DESCRIPTION
This PR restores compatibility with older CLI clients by decoding Base64 only when explicitly indicated, preventing errors and allowing old and new clients to coexist safely.